### PR TITLE
Unit tests, wires, and endianness

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo apt install software-properties-common
           sudo add-apt-repository ppa:wrathfulspatula/vm6502q
-          sudo apt install ocl-icd-opencl-dev opencl-headers pyqrack
+          sudo apt install ocl-icd-opencl-dev opencl-headers pyqrack ninja-build
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install wheel pytest pytest-cov pytest-mock --upgrade

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,11 @@ jobs:
           cmake ..
           sudo make install
           cd ../..
+          cd catalyst
+          git submodule update --init --depth=1
+          pip3 install -r requirements.txt
+          make all
+          cd ..
 
       - name: Install Plugin
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,12 +35,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install wheel pytest pytest-cov pytest-mock --upgrade
-          git clone https://github.com/PennyLaneAI/catalyst.git
-          cd catalyst
-          git submodule update --init --depth=1
-          pip install -r requirements.txt
-          make all
-          cd ..
 
       - name: Install Plugin
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,21 +29,16 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install ocl-icd-opencl-dev opencl-headers
+          sudo apt install software-properties-common
+          sudo add-apt-repository ppa:wrathfulspatula/vm6502q
+          sudo apt install ocl-icd-opencl-dev opencl-headers pyqrack
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install wheel pytest pytest-cov pytest-mock --upgrade
           git clone https://github.com/PennyLaneAI/catalyst.git
-          git clone https://github.com/unitaryfund/qrack.git
-          cd qrack
-          mkdir _build
-          cd _build
-          cmake ..
-          sudo make install
-          cd ../..
           cd catalyst
           git submodule update --init --depth=1
-          pip3 install -r requirements.txt
+          pip install -r requirements.txt
           make all
           cd ..
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,18 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt install software-properties-common
-          sudo add-apt-repository ppa:wrathfulspatula/vm6502q
-          sudo apt install ocl-icd-opencl-dev opencl-headers pyqrack ninja-build libomp-dev
+          sudo apt install ocl-icd-opencl-dev opencl-headers
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install wheel pytest pytest-cov pytest-mock --upgrade
+          git clone https://github.com/PennyLaneAI/catalyst.git
+          git clone https://github.com/unitaryfund/qrack.git
+          cd qrack
+          mkdir _build
+          cd _build
+          cmake ..
+          sudo make install
+          cd ../..
 
       - name: Install Plugin
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo apt install software-properties-common
           sudo add-apt-repository ppa:wrathfulspatula/vm6502q
-          sudo apt install ocl-icd-opencl-dev opencl-headers pyqrack ninja-build
+          sudo apt install ocl-icd-opencl-dev opencl-headers pyqrack ninja-build libomp-dev
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install wheel pytest pytest-cov pytest-mock --upgrade

--- a/pennylane_qrack/QrackDeviceConfig.toml
+++ b/pennylane_qrack/QrackDeviceConfig.toml
@@ -132,19 +132,19 @@ wires = "wires"
 # Number of shots per job
 shots = "shots"
 # Use "hybrid" stabilizer optimization? (Default is "true"; non-Clifford circuits will fall back to near-Clifford or universal simulation)
-is_hybrid_stabilizer = "is_hybrid_stabilizer"
+is_hybrid_stabilizer = "isStabilizerHybrid"
 # Use "tensor network" optimization? (Default is "false"; prevents dynamic qubit de-allocation; might function sub-optimally with "hybrid" stabilizer enabled)
-is_tensor_network = "is_tensor_network"
+is_tensor_network = "isTensorNetwork"
 # Use Schmidt decomposition optimizations? (Default is "true")
-is_schmidt_decomposed = "is_schmidt_decomposed"
+is_schmidt_decomposed = "isSchmidtDecompose"
 # Distribute Schmidt-decomposed qubit subsystems to multiple GPUs or accelerators, if available? (Default is "true"; mismatched device capacities might hurt overall performance)
-is_schmidt_decomposition_parallel = "is_schmidt_decomposition_parallel"
+is_schmidt_decomposition_parallel = "isSchmidtDecomposeMulti"
 # Use "quantum binary decision diagram" ("QBDD") methods? (Default is "false"; note that QBDD is CPU-only)
-is_qbdd = "is_qbdd"
+is_qbdd = "isBinaryDecisionTree"
 # Use GPU acceleration? (Default is "true")
-is_gpu = "is_gpu"
+is_gpu = "isOpenCL"
 # Allocate GPU buffer from general host heap? (Default is "false"; "true" might improve performance or reliability in certain cases, like if using an Intel HD as accelerator)
-is_host_pointer = "is_host_pointer"
+is_host_pointer = "isHostPointer"
 
 # In the above example, a dictionary will be constructed at run time.
 # The dictionary will contain the string key "option_key" and its value

--- a/pennylane_qrack/QrackDeviceConfig.toml
+++ b/pennylane_qrack/QrackDeviceConfig.toml
@@ -44,8 +44,6 @@ CRY = { properties = [ "controllable", "invertible" ] }
 CRZ = { properties = [ "controllable", "invertible" ] }
 CRot = { properties = [ "controllable", "invertible" ] }
 U3 = { properties = [ "controllable", "invertible" ] }
-U2 = { properties = [ "controllable", "invertible" ] }
-U1 = { properties = [ "controllable", "invertible" ] }
 MultiControlledX = { properties = [ "controllable", "invertible" ] }
 Identity = { properties = [ "controllable", "invertible" ] }
 
@@ -78,6 +76,8 @@ Identity = { properties = [ "controllable", "invertible" ] }
 # IsingYY = {}
 # IsingZZ = {}
 # IsingXY = {}
+# U2 = {}
+# U1 = {}
 # QFT = {}
 
 # Gates which should be translated to QubitUnitary

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -544,7 +544,9 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
 
     auto AllocateQubit() -> QubitIdType override {
         if (allocated_qubits >= qubit_map.size()) {
-            throw std::runtime_error("Catalyst has requested more qubits than exist in device. (Set your wires count high enough, for the device.)");
+            throw std::runtime_error("Catalyst has requested more qubits than exist in device, with "
+                + std::to_string(allocated_qubits) + " allocated qubits. "
+                + "(Set your wires count high enough, for the device.)");
         }
         auto it = qubit_map.begin();
         std::advance(it, allocated_qubits);

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -747,8 +747,8 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     void PartialProbs(DataView<double, 1> &p, const std::vector<QubitIdType> &wires) override
     {
         RT_FAIL_IF((size_t)Qrack::pow2(wires.size()) != p.size(), "Invalid size for the pre-allocated probabilities vector");
-        reverseWires();
         auto &&dev_wires = getDeviceWires(wires);
+        std::reverse(dev_wires.begin(), dev_wires.end());
 #if FPPOW == 6
         qsim->ProbBitsAll(dev_wires, &(*(p.begin())));
 #else
@@ -756,7 +756,6 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         qsim->ProbBitsAll(dev_wires, _p.get());
         std::copy(_p.get(), _p.get() + p.size(), p.begin());
 #endif
-        reverseWires();
     }
     void Sample(DataView<double, 2> &samples, size_t shots) override
     {
@@ -787,7 +786,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         auto &&dev_wires = getDeviceWires(wires);
         std::vector<bitCapInt> qPowers(dev_wires.size());
         for (size_t i = 0U; i < qPowers.size(); ++i) {
-            qPowers[i] = Qrack::pow2((bitLenInt)dev_wires[qPowers.size() - (i + 1U)]);
+            qPowers[i] = Qrack::pow2(dev_wires[qPowers.size() - (i + 1U)]);
         }
         auto q_samples = qsim->MultiShotMeasureMask(qPowers, shots);
 

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -391,6 +391,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         , shots(1U)
         , qsim(nullptr)
     {
+        std::cout << kwargs << std::endl;
         // Cut leading '{' and trailing '}'
         kwargs.erase(0U, 1U);
         kwargs.erase(kwargs.size() - 1U);
@@ -408,10 +409,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         keyMap["'is_gpu'"] = 8;
         keyMap["'is_host_pointer'"] = 9;
 
-        // If no argument is present, allocate one wire by default
-        bitLenInt wires = 1U;
-        qubit_map[0U] = 0U;
-
+        bitLenInt wires = 0U;
         bool is_hybrid_stabilizer = true;
         bool is_tensor_network = false;
         bool is_schmidt_decomposed = true;
@@ -426,9 +424,10 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
             kwargs.erase(0, pos + 1U);
 
             if (key == "'wires'") {
-                // Clear the default wire map setup
-                wires = 0U;
-                qubit_map.clear();
+                // Handle if empty:
+                if (kwargs.find("<Wires = []>") != std::string::npos) {
+                    continue;
+                }
 
                 // Handle if integer
                 pos = kwargs.find(",");

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -169,16 +169,19 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
                 qsim->RZ(inverse ? -params[0U] : params[0U], target);
             }
         } else if (name == "Rot") {
+            const Qrack::real1 phi = inverse ? -params[2U] : params[0U];
+            const Qrack::real1 theta = inverse ? -params[1U] : params[1U];
+            const Qrack::real1 omega = inverse ? -params[0U] : params[2U];
+            const Qrack::real1 cos0 = (Qrack::real1)cos(theta / 2);
+            const Qrack::real1 sin0 = (Qrack::real1)sin(theta / 2);
+            const Qrack::complex expP = exp(Qrack::I_CMPLX * (phi + omega) / (2 * ONE_R1));
+            const Qrack::complex expM = exp(Qrack::I_CMPLX * (phi - omega) / (2 * ONE_R1));
+            const Qrack::complex mtrx[4U]{
+                cos0 / expP, -sin0 * expM,
+                sin0 / expM, cos0 * expP
+            };
             for (const bitLenInt& target : wires) {
-                if (inverse) {
-                    qsim->RZ(-params[2U], target);
-                    qsim->RY(-params[1U], target);
-                    qsim->RZ(-params[0U], target);
-                } else {
-                    qsim->RZ(params[0U], target);
-                    qsim->RY(params[1U], target);
-                    qsim->RZ(params[2U], target);
-                }
+                qsim->Mtrx(mtrx, target);
             }
         } else if (name == "U3") {
             for (const bitLenInt& target : wires) {
@@ -328,9 +331,9 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
                 qsim->UCPhase(control_wires, conj(bottomRight), bottomRight, target, controlPerm);
             }
         } else if ((name == "Rot") || (name == "CRot")) {
-            const Qrack::real1 phi = inverse ? -params[0U] : params[0U];
+            const Qrack::real1 phi = inverse ? -params[2U] : params[0U];
             const Qrack::real1 theta = inverse ? -params[1U] : params[1U];
-            const Qrack::real1 omega = inverse ? -params[2U] : params[2U];
+            const Qrack::real1 omega = inverse ? -params[0U] : params[2U];
             const Qrack::real1 cos0 = (Qrack::real1)cos(theta / 2);
             const Qrack::real1 sin0 = (Qrack::real1)sin(theta / 2);
             const Qrack::complex expP = exp(Qrack::I_CMPLX * (phi + omega) / (2 * ONE_R1));

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -151,7 +151,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
             qsim->CU(c, wires[1U], ZERO_R1, ZERO_R1, inverse ? -params[0U] : params[0U]);
             qsim->Swap(wires[0U], wires[1U]);
             qsim->CU(c, wires[1U], ZERO_R1, ZERO_R1, inverse ? -params[0U] : params[0U]);
-        } else if ((name == "PhaseShift") || (name == "U1")) {
+        } else if (name == "PhaseShift") {
             const Qrack::complex bottomRight = exp(Qrack::I_CMPLX * (Qrack::real1)(inverse ? -params[0U] : params[0U]));
             for (const bitLenInt& target : wires) {
                 qsim->Phase(Qrack::ONE_CMPLX, bottomRight, target);
@@ -187,20 +187,6 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
                 } else {
                     qsim->U(target, params[0U], params[1U], params[2U]);
                 }
-            }
-        } else if (name == "U2") {
-            const Qrack::real1 th = inverse ? -params[0U] : params[0U];
-            const Qrack::real1 ph = inverse ? -params[1U] : params[1U];
-            const Qrack::complex u2Mtrx[4U] = {
-                Qrack::SQRT1_2_R1,
-                Qrack::SQRT1_2_R1 * -exp(Qrack::complex(ZERO_R1, ph)),
-                Qrack::SQRT1_2_R1 * exp(Qrack::complex(ZERO_R1, th)),
-                Qrack::SQRT1_2_R1 * exp(Qrack::complex(ZERO_R1, th + ph)),
-            };
-            Qrack::complex iU2Mtrx[4U];
-            Qrack::inv2x2(u2Mtrx, iU2Mtrx);
-            for (const bitLenInt& target : wires) {
-                qsim->Mtrx(inverse ? iU2Mtrx : u2Mtrx, target);
             }
         } else if (name != "Identity") {
             throw std::domain_error("Unrecognized gate name: " + name);
@@ -305,7 +291,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
                     qsim->X(control_wires[i]);
                 }
             }
-        } else if ((name == "PhaseShift") || (name == "U1") || (name == "ControlledPhaseShift") || (name == "CPhase")) {
+        } else if ((name == "PhaseShift") || (name == "ControlledPhaseShift") || (name == "CPhase")) {
             const Qrack::complex bottomRight = exp(Qrack::I_CMPLX * (Qrack::real1)(inverse ? -params[0U] : params[0U]));
             for (const bitLenInt& target : wires) {
                 qsim->UCPhase(control_wires, Qrack::ONE_CMPLX, bottomRight, target, controlPerm);
@@ -372,20 +358,6 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
             Qrack::inv2x2(mtrx, iMtrx);
             for (const bitLenInt& target : wires) {
                 qsim->UCMtrx(control_wires, inverse ? iMtrx : mtrx, target, controlPerm);
-            }
-        } else if (name == "U2") {
-            const Qrack::real1 th = params[0U];
-            const Qrack::real1 ph = params[1U];
-            const Qrack::complex u2Mtrx[4U] = {
-                Qrack::SQRT1_2_R1,
-                Qrack::SQRT1_2_R1 * exp(Qrack::complex(ZERO_R1, ph)),
-                Qrack::SQRT1_2_R1 * exp(Qrack::complex(ZERO_R1, th)),
-                Qrack::SQRT1_2_R1 * exp(Qrack::complex(ZERO_R1, th + ph)),
-            };
-            Qrack::complex iU2Mtrx[4U];
-            Qrack::inv2x2(u2Mtrx, iU2Mtrx);
-            for (const bitLenInt& target : wires) {
-                qsim->UCMtrx(control_wires, inverse ? iU2Mtrx : u2Mtrx, target, controlPerm);
             }
         } else if (name != "Identity") {
             throw std::domain_error("Unrecognized gate name: " + name);

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -424,8 +424,9 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
             kwargs.erase(0, pos + 1U);
 
             if (key == "'wires'") {
-                // Handle if empty:
-                if (kwargs.find("<Wires = []>") != std::string::npos) {
+                // Handle if empty
+                // We look for ',' or npos, to respect other Wires value kwargs
+                if (kwargs.find("<Wires = []>") != kwargs.find("<Wires = []>,")) {
                     continue;
                 }
 

--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -154,7 +154,7 @@ class QrackDevice(QubitDevice):
             os.path.dirname(sys.modules[__name__].__file__) + "/libqrack_device.so",
         )
 
-    def __init__(self, wires=0, shots=None, **kwargs):
+    def __init__(self, wires=1, shots=None, **kwargs):
         super().__init__(wires=wires, shots=shots)
 
         if "isTensorNetwork" in kwargs:

--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -154,7 +154,7 @@ class QrackDevice(QubitDevice):
             os.path.dirname(sys.modules[__name__].__file__) + "/libqrack_device.so",
         )
 
-    def __init__(self, wires=1, shots=None, **kwargs):
+    def __init__(self, wires=0, shots=None, **kwargs):
         super().__init__(wires=wires, shots=shots)
 
         if "isTensorNetwork" in kwargs:

--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -515,20 +515,22 @@ class QrackDevice(QubitDevice):
                 device_wires.labels[-1],
             )
         elif opname == "U2":
+            sqrt1_2 = 1/math.sqrt(2)
             u2_mtrx = [
-                1,
-                cmath.exp(1j * par[1]),
-                cmath.exp(1j * par[0]),
-                cmath.exp(1j * (par[0] + par[1])),
+                sqrt1_2,
+                sqrt1_2 * cmath.exp(1j * par[1]),
+                sqrt1_2 * cmath.exp(1j * par[0]),
+                sqrt1_2 * cmath.exp(1j * (par[0] + par[1])),
             ]
             for label in device_wires.labels:
                 self._state.mtrx(u2_mtrx, label)
         elif opname == "U2.inv":
+            sqrt1_2 = 1/math.sqrt(2)
             iu2_mtrx = [
-                1,
-                cmath.exp(1j * -par[1]),
-                cmath.exp(1j * -par[0]),
-                cmath.exp(1j * (-par[0] - par[1])),
+                sqrt1_2,
+                sqrt1_2 * cmath.exp(1j * -par[1]),
+                sqrt1_2 * cmath.exp(1j * -par[0]),
+                sqrt1_2 * cmath.exp(1j * (-par[0] + -par[1])),
             ]
             for label in device_wires.labels:
                 self._state.mtrx(iu2_mtrx, label)

--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -338,16 +338,17 @@ class QrackDevice(QubitDevice):
             theta = par[1]
             omega = par[2]
             if ".inv" in opname:
-                phi = -phi
+                tmp = phi
+                phi = -omega
                 theta = -theta
-                omega = -omega
+                omega = -phi
             c = math.cos(theta / 2)
             s = math.sin(theta / 2)
             mtrx = [
                 cmath.exp(-0.5j * (phi + omega)) * c,
                 cmath.exp(0.5j * (phi - omega)) * s,
                 cmath.exp(-0.5j * (phi - omega)) * s,
-                cmath.exp(0.5j * (phi + omega)) * c,
+                cmath.exp(0.5j * (phi + omega)) * np.cos(theta / 2),
             ]
             self._state.mcmtrx(device_wires.labels[:-1], mtrx, device_wires.labels[-1])
         elif opname in ["SWAP", "SWAP.inv"]:

--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -127,10 +127,6 @@ class QrackDevice(QubitDevice):
         "C(SX)",
         "PhaseShift",
         "C(PhaseShift)",
-        "U1",
-        "C(U1)",
-        "U2",
-        "C(U2)",
         "U3",
         "C(U3)",
         "Rot",
@@ -472,21 +468,21 @@ class QrackDevice(QubitDevice):
                 [(1 + 1j) / 2, (1 - 1j) / 2, (1 - 1j) / 2, (1 + 1j) / 2],
                 device_wires.labels[-1],
             )
-        elif opname in ["PhaseShift", "U1"]:
+        elif opname == "PhaseShift":
             p_mtrx = [1, 0, 0, cmath.exp(1j * par[0])]
             for label in device_wires.labels:
                 self._state.mtrx(p_mtrx, label)
-        elif opname in ["PhaseShift.inv", "U1.inv"]:
+        elif opname == "PhaseShift.inv":
             ip_mtrx = [1, 0, 0, cmath.exp(1j * -par[0])]
             for label in device_wires.labels:
                 self._state.mtrx(ip_mtrx, label)
-        elif opname in ["C(PhaseShift)", "C(U1)"]:
+        elif opname == "C(PhaseShift)":
             self._state.mtrx(
                 device_wires.labels[:-1],
                 [1, 0, 0, cmath.exp(1j * par[0])],
                 device_wires.labels[-1],
             )
-        elif opname in ["C(PhaseShift).inv", "C(U1).inv"]:
+        elif opname == "C(PhaseShift).inv":
             self._state.mtrx(
                 device_wires.labels[:-1],
                 [1, 0, 0, cmath.exp(1j * -par[0])],
@@ -514,54 +510,12 @@ class QrackDevice(QubitDevice):
                 [1, 0, 0, cmath.exp(1j * -par[0])],
                 device_wires.labels[-1],
             )
-        elif opname == "U2":
-            sqrt1_2 = 1/math.sqrt(2)
-            u2_mtrx = [
-                sqrt1_2,
-                sqrt1_2 * cmath.exp(1j * par[1]),
-                sqrt1_2 * cmath.exp(1j * par[0]),
-                sqrt1_2 * cmath.exp(1j * (par[0] + par[1])),
-            ]
-            for label in device_wires.labels:
-                self._state.mtrx(u2_mtrx, label)
-        elif opname == "U2.inv":
-            sqrt1_2 = 1/math.sqrt(2)
-            iu2_mtrx = [
-                sqrt1_2,
-                sqrt1_2 * cmath.exp(1j * -par[1]),
-                sqrt1_2 * cmath.exp(1j * -par[0]),
-                sqrt1_2 * cmath.exp(1j * (-par[0] + -par[1])),
-            ]
-            for label in device_wires.labels:
-                self._state.mtrx(iu2_mtrx, label)
-        elif opname == "C(U2)":
-            self._state.mcmtrx(
-                device_wires.labels[:-1],
-                [
-                    1,
-                    cmath.exp(1j * par[1]),
-                    cmath.exp(1j * par[0]),
-                    cmath.exp(1j * (par[0] + par[1])),
-                ],
-                device_wires.labels[-1],
-            )
-        elif opname == "C(U2).inv":
-            self._state.mcmtrx(
-                device_wires.labels[:-1],
-                [
-                    1,
-                    cmath.exp(1j * -par[1]),
-                    cmath.exp(1j * -par[0]),
-                    cmath.exp(1j * (-par[0] - par[1])),
-                ],
-                device_wires.labels[-1],
-            )
         elif opname == "U3":
             for label in device_wires.labels:
                 self._state.u(label, par[0], par[1], par[2])
         elif opname == "U3.inv":
             for label in device_wires.labels:
-                self._state.u(label, -par[0], -par[1], -par[2])
+                self._state.u(label, -par[0], -par[2], -par[1])
         elif opname == "Rot":
             for label in device_wires.labels:
                 self._state.r(Pauli.PauliZ, par[0], label)
@@ -585,8 +539,8 @@ class QrackDevice(QubitDevice):
                 device_wires.labels[:-1],
                 device_wires.labels[-1],
                 -par[0],
-                -par[1],
                 -par[2],
+                -par[1],
             )
         elif opname not in [
             "Identity",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pennylane>=0.32
+pennylane-catalyst>=0.6
 pyqrack>=0.13.0
 numpy~=1.16
 scikit-build

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -54,9 +54,6 @@ c_phase_shift = lambda phi: np.diag([1, 1, 1, np.exp(1j * phi)])
 rx = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * X
 ry = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Y
 rz = lambda theta: np.cos(theta / 2) * I + 1j * np.sin(-theta / 2) * Z
-u2 = lambda phi, delta: np.array(
-    [[sqrt1_2, sqrt1_2 * np.exp(1j * delta)], [sqrt1_2 * np.exp(1j * phi), sqrt1_2 * np.exp(1j * (phi + delta))]]
-)
 u3 = lambda theta, phi, delta: np.array(
     [
         [np.cos(theta / 2), -np.exp(1j * delta) * np.sin(theta / 2)],
@@ -141,15 +138,11 @@ single_qubit_param = [
     (qml.adjoint(qml.RZ(0, wires=0)), lambda theta: rz(-theta)),
     (qml.adjoint(qml.PhaseShift(0, wires=0)), lambda theta: phase_shift(-theta)),
 ]
-single_qubit_two_param = [
-    (qml.U2(0, 0, wires=0), u2),
-    (qml.adjoint(qml.U2(0, 0, wires=0)), lambda phi, delta: u2(-phi, -delta)),
-]
 single_qubit_three_param = [
     (qml.U3(0, 0, 0, wires=0), u3),
     (
         qml.adjoint(qml.U3(0, 0, 0, wires=0)),
-        lambda theta, phi, delta: u3(-theta, -phi, -delta),
+        lambda theta, phi, delta: u3(-theta, -delta, -phi),
     ),
 ]
 # list of all non-parametrized two-qubit gates
@@ -368,22 +361,6 @@ class TestStateApply:
         assert np.allclose(res, expected, tol)
 
     @pytest.mark.parametrize("phi", [0.126, -0.721])
-    @pytest.mark.parametrize("delta", [0.5432, -0.232])
-    @pytest.mark.parametrize("op,func", single_qubit_two_param)
-    def test_single_qubit_two_parameters(self, init_state, op, func, phi, delta, tol):
-        """Test PauliX application"""
-        dev = QrackDevice(1, isOpenCL=False)
-        state = init_state(1)
-
-        op.data = [phi, delta]
-        dev.apply([qml.QubitStateVector(state, wires=[0]), op])
-        dev._obs_queue = []
-
-        res = dev.state
-        expected = func(phi, delta) @ state
-        assert np.allclose(res, expected, tol)
-
-    @pytest.mark.parametrize("phi", [0.126, -0.721])
     @pytest.mark.parametrize("theta", [0.5432, -0.232])
     @pytest.mark.parametrize("omega", [1.213, -0.221])
     @pytest.mark.parametrize("op,func", single_qubit_three_param)
@@ -400,6 +377,32 @@ class TestStateApply:
 
         res = dev.state
         expected = func(phi, theta, omega) @ state
+        assert np.allclose(res, expected, tol)
+
+    @pytest.mark.parametrize("phi", [0.126, -0.721])
+    @pytest.mark.parametrize("theta", [0.5432, -0.232])
+    @pytest.mark.parametrize("omega", [1.213, -0.221])
+    @pytest.mark.parametrize("op,func", single_qubit_three_param)
+    def test_single_qubit_three_parameters_qjit(
+        self, init_state, op, func, phi, theta, omega, tol
+    ):
+        """Test PauliX application"""
+        dev = QrackDevice(1, isOpenCL=False)
+        state = init_state(1)
+
+        op.data = [phi, theta, omega]
+        @qjit
+        @qml.qnode(dev)
+        def circuit():
+            qml.StatePrep(state, wires=[0])
+            qml.apply(op)
+            return qml.probs()
+
+        dev._obs_queue = []
+
+        res = circuit()
+        expected = func(phi, theta, omega) @ state
+        expected = [(x * x.conj()).real for x in expected]
         assert np.allclose(res, expected, tol)
 
     @pytest.mark.parametrize("op, mat", two_qubit)

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -174,7 +174,7 @@ two_qubit_three_param = [
     (qml.CRot(0, 0, 0, wires=[0, 1]), crot),
     (
         qml.adjoint(qml.CRot(0, 0, 0, wires=[0, 1])),
-        lambda phi, theta, omega: crot(-phi, -theta, -omega),
+        lambda phi, theta, omega: crot(-omega, -theta, -phi),
     ),
 ]
 # list of all three-qubit gates
@@ -579,7 +579,9 @@ class TestStateApply:
         dev._obs_queue = []
 
         res = dev.state
+        res = [(x * np.conjugate(x)).real for x in res]
         expected = func(phi, theta, omega) @ state
+        expected = [(x * x.conj()).real for x in expected]
         assert np.allclose(res, expected, tol)
 
     def test_apply_errors_qubit_state_vector(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@
 import numpy as np
 import pennylane as qml
 from pennylane_qrack.qrack_device import QrackDevice
-
+from catalyst import qjit
 
 class TestIntegration:
     """Some basic integration tests."""
@@ -36,6 +36,25 @@ class TestIntegration:
         theta = 0.432
         phi = 0.123
 
+        @qml.qnode(dev)
+        def circuit():
+            qml.adjoint(qml.RY(theta, wires=[0]))
+            qml.RY(phi, wires=[1])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliX(wires=0)), qml.expval(qml.PauliX(wires=1))
+
+        res = circuit()
+        expected = np.array([np.sin(-theta) * np.sin(phi), np.sin(phi)])
+        assert np.allclose(res, expected, atol=0.05)
+
+    def test_expectation_qjit(self):
+        """Test that expectation of a non-trivial circuit is correct."""
+        dev = QrackDevice(2, shots=int(1e6), isOpenCL=False)
+
+        theta = 0.432
+        phi = 0.123
+
+        @qjit
         @qml.qnode(dev)
         def circuit():
             qml.adjoint(qml.RY(theta, wires=[0]))


### PR DESCRIPTION
This PR fixes wire map parsing and "endianness" conventions. It also adds a full suite of unit tests for the Catalyst Qrack device back end.