### PR TITLE
Samples and Counts output debugging

### DIFF
--- a/pennylane_qrack/_version.py
+++ b/pennylane_qrack/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -761,7 +761,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     {
         // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
         // that could be instead implied by the size of "samples."
-        RT_FAIL_IF(samples.size() != shots, "Invalid size for the pre-allocated samples");
+        RT_FAIL_IF(samples.size() != shots * qsim->GetQubitCount(), "Invalid size for the pre-allocated samples");
 
         std::vector<bitCapInt> qPowers(qsim->GetQubitCount());
         for (bitLenInt i = 0U; i < qPowers.size(); ++i) {
@@ -781,7 +781,8 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     {
         // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
         // that could be instead implied by the size of "samples."
-        RT_FAIL_IF(samples.size() != shots, "Invalid size for the pre-allocated samples");
+        std::cout << shots << std::endl;
+        RT_FAIL_IF(samples.size() != shots * wires.size(), "Invalid size for the pre-allocated samples");
 
         auto &&dev_wires = getDeviceWires(wires);
         std::vector<bitCapInt> qPowers(dev_wires.size());
@@ -804,7 +805,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
         // that could be instead implied by the size of "eigvals"/"counts".
         const size_t numQubits = qsim->GetQubitCount();
-        const size_t numElements = (size_t)qsim->GetMaxQPower();
+        const size_t numElements = 1U << numQubits;
 
         RT_FAIL_IF(eigvals.size() != numElements || counts.size() != numElements,
                    "Invalid size for the pre-allocated counts");
@@ -835,7 +836,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
         // that could be instead implied by the size of "eigvals"/"counts".
         const size_t numQubits = wires.size();
-        const size_t numElements = (size_t)Qrack::pow2(numQubits);
+        const size_t numElements = 1U << numQubits;
 
         RT_FAIL_IF(eigvals.size() != numElements || counts.size() != numElements,
                    "Invalid size for the pre-allocated counts");

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -761,10 +761,9 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     {
         auto samplesIter = samples.begin();
         auto q_samplesIter = q_samples.begin();
-        for (size_t shot = 0U; shot < shots; ++shot) {
-            bitCapInt sample = q_samplesIter->first;
+        for (auto q_samplesIter = q_samples.begin(); q_samplesIter != q_samples.end(); ++q_samplesIter) {
+            const bitCapInt sample = q_samplesIter->first;
             int shots = q_samplesIter->second;
-            ++q_samplesIter;
             for (; shots > 0; --shots) {
                 for (size_t wire = 0U; wire < numQubits; ++wire) {
                     *(samplesIter++) = bi_compare_0((sample >> wire) & 1U) ? 1.0 : 0.0;
@@ -802,7 +801,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     void _CountsBody(const size_t numQubits, const std::map<bitCapInt, int>& q_samples, DataView<int64_t, 1> &counts)
     {
         for (auto q_samplesIter = q_samples.begin(); q_samplesIter != q_samples.end(); ++q_samplesIter) {
-            bitCapInt sample = q_samplesIter->first;
+            const bitCapInt sample = q_samplesIter->first;
             int shots = q_samplesIter->second;
             std::bitset<1U << QBCAPPOW> basisState;
             for (size_t wire = 0; wire < numQubits; wire++) {

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -773,8 +773,6 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     }
     void Sample(DataView<double, 2> &samples, size_t shots) override
     {
-        // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
-        // that could be instead implied by the size of "samples."
         RT_FAIL_IF(samples.size() != shots * qsim->GetQubitCount(), "Invalid size for the pre-allocated samples");
 
         std::vector<bitCapInt> qPowers(qsim->GetQubitCount());
@@ -786,8 +784,6 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     }
     void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires, size_t shots) override
     {
-        // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
-        // that could be instead implied by the size of "samples."
         RT_FAIL_IF(samples.size() != shots * wires.size(), "Invalid size for the pre-allocated samples");
 
         auto &&dev_wires = getDeviceWires(wires);
@@ -815,8 +811,6 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     void Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
                 size_t shots) override
     {
-        // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
-        // that could be instead implied by the size of "eigvals"/"counts".
         const size_t numQubits = qsim->GetQubitCount();
         const size_t numElements = 1U << numQubits;
 
@@ -838,8 +832,6 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
                        const std::vector<QubitIdType> &wires, size_t shots) override
     {
-        // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
-        // that could be instead implied by the size of "eigvals"/"counts".
         const size_t numQubits = wires.size();
         const size_t numElements = 1U << numQubits;
 

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -789,7 +789,6 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
     {
         // TODO: We could suggest, for upstream, that "shots" is a redundant parameter
         // that could be instead implied by the size of "samples."
-        std::cout << shots << std::endl;
         RT_FAIL_IF(samples.size() != shots * wires.size(), "Invalid size for the pre-allocated samples");
 
         auto &&dev_wires = getDeviceWires(wires);

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -773,7 +773,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         for (size_t shot = 0U; shot < shots; ++shot) {
             bitCapInt sample = q_samples[shot];
             for (size_t wire = 0U; wire < qPowers.size(); ++wire) {
-                *(samplesIter++) = bi_to_double((sample >> wire) & 1U);
+                *(samplesIter++) = bi_compare_0(sample & (1U << wire)) ? 1.0 : 0.0;
             }
         }
     }
@@ -795,7 +795,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         for (size_t shot = 0U; shot < shots; ++shot) {
             bitCapInt sample = q_samples[shot];
             for (size_t wire = 0U; wire < qPowers.size(); ++wire) {
-                *(samplesIter++) = bi_to_double((sample >> wire) & 1U);
+                *(samplesIter++) = bi_compare_0(sample & (1U << wire)) ? 1.0 : 0.0;
             }
         }
     }
@@ -824,7 +824,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
             std::bitset<1U << QBCAPPOW> basisState;
             size_t idx = numQubits;
             for (size_t wire = 0; wire < numQubits; wire++) {
-                basisState[--idx] = bi_compare_0((sample >> wire) & 1U);
+                basisState[--idx] = bi_compare_0(sample & (1U << wire));
             }
             ++counts(static_cast<size_t>(basisState.to_ulong()));
         }

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -804,11 +804,11 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         for (auto q_samplesIter = q_samples.begin(); q_samplesIter != q_samples.end(); ++q_samplesIter) {
             bitCapInt sample = q_samplesIter->first;
             int shots = q_samplesIter->second;
+            std::bitset<1U << QBCAPPOW> basisState;
+            for (size_t wire = 0; wire < numQubits; wire++) {
+                basisState[wire] = bi_compare_0((sample >> wire) & 1U);
+            }
             for (; shots > 0; --shots) {
-                std::bitset<1U << QBCAPPOW> basisState;
-                for (size_t wire = 0; wire < numQubits; wire++) {
-                    basisState[wire] = bi_compare_0((sample >> wire) & 1U);
-                }
                 ++counts(static_cast<size_t>(basisState.to_ulong()));
             }
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pennylane>=0.32
 pennylane-catalyst>=0.6
 pyqrack>=0.13.0
 numpy~=1.16
-scikit-build
+scikit-build>=0.1.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ with open("./pennylane_qrack/_version.py") as f:
 
 requirements = [
     "pennylane>=0.32",
+    "pennylane-catalyst>=0.6",
     "pyqrack>=0.13.0",
     "numpy~=1.16",
     "scikit-build>=0.1.0",


### PR DESCRIPTION
This PR fixes the conversion from Qrack integer bit string sample histograms to the expected output formats of PennyLane Catalyst `Samples()` and `Counts()`.