### PR TITLE
Documentation update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 PennyLane-Qrack Plugin
 #######################
 
+.. header-start-inclusion-marker-do-not-remove
+
 The PennyLane-Qrack plugin integrates the Qrack quantum computing framework with PennyLane's quantum machine learning capabilities.
 
 This plugin is addapted from the `PennyLane-Qulacs plugin, <https://github.com/PennyLaneAI/pennylane-qulacs>`__ under the Apache License 2.0, with many thanks to the original developers!
@@ -8,6 +10,10 @@ This plugin is addapted from the `PennyLane-Qulacs plugin, <https://github.com/P
 `PennyLane <https://pennylane.readthedocs.io>`__ is a cross-platform Python library for quantum machine learning, automatic differentiation, and optimization of hybrid quantum-classical computations.
 
 `unitaryfund/qrack <https://github.com/unitaryfund/qrack>`__ (formerly **vm6502q/qrack**) is a software library for quantum computing, written in C++ and with GPU support.
+
+`PennyLane Catalyst <https://docs.pennylane.ai/projects/catalyst/en/stable/index.html>`__ provides optional quantum just-in-time (QJIT) compilation, for improved performance.
+
+.. header-end-inclusion-marker-do-not-remove
 
 Features
 ========

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Features
 Installation
 ============
 
-This plugin requires Python version 3.6 or above, as well as PennyLane and the Qrack library.
+This plugin requires Python version 3.9 or above, as well as PennyLane and the Qrack library.
 
 Installation of this plugin as well as all its Python dependencies can be done using ``pip`` (or ``pip3``, as appropriate):
 
@@ -35,7 +35,7 @@ Dependencies
 
 PennyLane-Qrack requires the following libraries be installed:
 
-* `Python <http://python.org/>`__ >= 3.8
+* `Python <http://python.org/>`__ >= 3.9
 * `Qrack <https://github.com/unitaryfund/qrack>`__ >= 9.0
 
 as well as the following Python packages:

--- a/doc/devices/simulator.rst
+++ b/doc/devices/simulator.rst
@@ -58,7 +58,7 @@ This is a complete list of boolean options and their meanings:
     |                           |             | (Non-Clifford circuits will fall back to near-Clifford or universal simulation.)   |
     +---------------------------+-------------+------------------------------------------------------------------------------------+
     | `isTensorNetwork`         | True        | Use "tensor network" optimization?                                                 |
-    |                           |             | (Non-Clifford circuits will fall back to near-Clifford or universal simulation.)   |
+    |                           |             | (This option locally simplifies circuits, just-in-time, before running them.)      |
     +---------------------------+-------------+------------------------------------------------------------------------------------+
     | `isSchmidtDecompose`      | True        | Use Schmidt decomposition optimizations?                                           |
     |                           |             |                                                                                    |
@@ -81,4 +81,4 @@ Supported operations
 ~~~~~~~~~~~~~~~~~~~~
 
 The ``qrack.simulator`` device supports all PennyLane
-`operations and observables <https://pennylane.readthedocs.io/en/stable/introduction/operations.html>`_:
+`operations and observables <https://pennylane.readthedocs.io/en/stable/introduction/operations.html>`_.


### PR DESCRIPTION
Per issue #9, this implements all suggestions except for removing the API section. (Personally, I could go either way, about including it or removing it, because it at least answers the natural question, "Q: What is the API I use, as your end user?" "A: Explicitly, you only need to know and use the PennyLane API.")