### PR TITLE
Fix reallocation after free

### DIFF
--- a/pennylane_qrack/_version.py
+++ b/pennylane_qrack/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/pennylane_qrack/qrack_device.cpp
+++ b/pennylane_qrack/qrack_device.cpp
@@ -502,7 +502,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
             }
         }
 
-        qsim = QSIM_CONFIG(mapped_qubits);
+        qsim = QSIM_CONFIG(0U);
     }
 
     QrackDevice &operator=(const QuantumDevice &) = delete;
@@ -516,6 +516,7 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
                 + std::to_string(allocated_qubits) + " allocated qubits. "
                 + "(Set your wires count high enough, for the device.)");
         }
+        qsim->Allocate(1U);
         auto it = qubit_map.begin();
         std::advance(it, allocated_qubits);
         const QubitIdType label = it->first;
@@ -589,13 +590,13 @@ struct QrackDevice final : public Catalyst::Runtime::QuantumDevice {
         qsim->M(id);
         // Deallocate
         qsim->Dispose(id, 1U);
-        qubit_map.erase(label);
+        --allocated_qubits;
     }
     void ReleaseAllQubits() override
     {
         // State vector is left empty
         qsim = QSIM_CONFIG(0U);
-        qubit_map.clear();
+        allocated_qubits = 0;
     }
     [[nodiscard]] auto GetNumQubits() const -> size_t override
     {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,6 +29,26 @@ class TestIntegration:
         assert dev.short_name == "qrack.simulator"
         assert "model" in dev.__class__.capabilities()
 
+    def test_realloc(self):
+        """Test that the Qrack device can reallocate after free."""
+        dev = QrackDevice(2, shots=int(1e6), isOpenCL=False)
+
+        @qjit
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.Hadamard(wires=0)
+            return qml.expval(qml.PauliY(0))
+
+        circuit()
+        try:
+            circuit()
+        except:
+            pytest.fail("Reallocation after free failed")
+
     def test_expectation(self):
         """Test that expectation of a non-trivial circuit is correct."""
         dev = QrackDevice(2, shots=int(1e6), isOpenCL=False)


### PR DESCRIPTION
This allows a Qrack device to reallocate (up to the original wires size requested in the constructor) after releasing qubits.