### PR TITLE
'rotations' parameter is redundant if Qrack converts to observable basis

### DIFF
--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -167,9 +167,6 @@ class QrackDevice(QubitDevice):
             self._state.swap(i, end - i)
 
     def apply(self, operations, **kwargs):
-        self.apply_operations(operations)
-
-    def apply_operations(self, operations):
         """Apply the circuit operations to the state.
 
         This method serves as an auxiliary method to :meth:`~.QrackDevice.apply`.

--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -167,13 +167,7 @@ class QrackDevice(QubitDevice):
             self._state.swap(i, end - i)
 
     def apply(self, operations, **kwargs):
-        rotations = kwargs.get("rotations", [])
-
         self.apply_operations(operations)
-
-        # Rotating the state for measurement in the computational basis
-        if rotations:
-            self.apply_operations(rotations)
 
     def apply_operations(self, operations):
         """Apply the circuit operations to the state.


### PR DESCRIPTION
`expval()` has a parameter for the observable type to calculate, but this turns out to be redundant with `rotations` parameter passed into `apply_operations()`: I realize now, one _either_ uses `rotations` parameter _or_ transforms basis for `expval()` parameters, not both.