### PR TITLE
Added state to the list of supported measurements in device config.

### DIFF
--- a/pennylane_qrack/QrackDeviceConfig.toml
+++ b/pennylane_qrack/QrackDeviceConfig.toml
@@ -105,6 +105,7 @@ Prod = {}
 Expval = {}
 Var = {}
 Probs = {}
+State  = { condition = [ "analytic" ] }
 Sample = { condition = [ "finiteshots" ] }
 Counts = { condition = [ "finiteshots" ] }
 


### PR DESCRIPTION
state is missed from the list of supported measurement processes. This PR simply adds it to the Qrack device config file. 