### PR TITLE
Fix import in shots=None case

### DIFF
--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -175,30 +175,30 @@ class QrackDevice(QubitDevice):
 
     def __init__(self, wires=0, shots=None, **kwargs):
         options = dict(kwargs)
-        if 'isStabilizerHybrid' in options:
-            self.isStabilizerHybrid = options['isStabilizerHybrid']
-        if 'isTensorNetwork' in options:
-            self.isTensorNetwork = options['isTensorNetwork']
-        if 'isSchmidtDecompose' in options:
-            self.isSchmidtDecompose = options['isSchmidtDecompose']
-        if 'isBinaryDecisionTree' in options:
-            self.isBinaryDecisionTree = options['isBinaryDecisionTree']
-        if 'isOpenCL' in options:
-            self.isOpenCL = options['isOpenCL']
-        if 'isHostPointer' in options:
-            self.isHostPointer = options['isHostPointer']
-        if 'noise' in options:
-            self.noise = options['noise']
+        if "isStabilizerHybrid" in options:
+            self.isStabilizerHybrid = options["isStabilizerHybrid"]
+        if "isTensorNetwork" in options:
+            self.isTensorNetwork = options["isTensorNetwork"]
+        if "isSchmidtDecompose" in options:
+            self.isSchmidtDecompose = options["isSchmidtDecompose"]
+        if "isBinaryDecisionTree" in options:
+            self.isBinaryDecisionTree = options["isBinaryDecisionTree"]
+        if "isOpenCL" in options:
+            self.isOpenCL = options["isOpenCL"]
+        if "isHostPointer" in options:
+            self.isHostPointer = options["isHostPointer"]
+        if "noise" in options:
+            self.noise = options["noise"]
         super().__init__(wires=wires, shots=shots)
         self._state = QrackSimulator(
             self.num_wires,
-            isStabilizerHybrid = self.isStabilizerHybrid,
+            isStabilizerHybrid=self.isStabilizerHybrid,
             isTensorNetwork=self.isTensorNetwork,
             isSchmidtDecompose=self.isSchmidtDecompose,
             isBinaryDecisionTree=self.isBinaryDecisionTree,
             isOpenCL=self.isOpenCL,
             isHostPointer=self.isHostPointer,
-            noise = self.noise
+            noise=self.noise,
         )
 
     def _reverse_state(self):

--- a/pennylane_qrack/qrack_device.py
+++ b/pennylane_qrack/qrack_device.py
@@ -24,7 +24,7 @@ import itertools as it
 
 import numpy as np
 
-from pennylane import QubitDevice, DeviceError
+from pennylane import QubitDevice, DeviceError, QuantumFunctionError
 from pennylane.ops import (
     QubitStateVector,
     BasisState,
@@ -649,7 +649,7 @@ class QrackDevice(QubitDevice):
 
     def generate_samples(self):
         if self.shots is None:
-            raise qml.QuantumFunctionError(
+            raise QuantumFunctionError(
                 "The number of shots has to be explicitly set on the device "
                 "when using sample-based measurements."
             )


### PR DESCRIPTION
This was failing in the case of shots=None, because it couldn't import the qml module.

I tried running tests with `make test, but the command fails even on main. Most likely because I am using an old version of qrack (it'd be useful if the README specified how to deal with that case).
